### PR TITLE
Add a CI workflow to create a release whenever `main` is pushed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out this repository
+      - uses: actions/checkout@v2
+
+      # Determine the current date, used for the tag and release name
+      - name: Determine current date
+        run: |
+          echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      # Create a release containing all SVDs and using the current date as the
+      # tag/release name
+      - uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "svd/*.svd"
+          tag: ${{ env.CURRENT_DATE }}


### PR DESCRIPTION
Whenever the `main` branch is pushed to, this will action will create a tag and a release, both named using the current date (eg. `2022-07-22`). Each release will contain all SVD files, regardless of whether or not a specific file has been updated. An example release can be found [here](https://github.com/jessebraham/svd/releases/tag/2022-07-22).

@igrr @brianignacio5 does this seem suitable?

Closes #22. 