### PR TITLE
Add CI job to check SVDs against SVD XML scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,31 @@ on:
       - main
 
 jobs:
+  xmllint:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out this repository
+      - uses: actions/checkout@v2
+
+      - name: Install xmllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+
+      - name: Get SVD schema
+        run: |
+          curl -o CMSIS-SVD.xsd https://raw.githubusercontent.com/ARM-software/CMSIS_5/develop/CMSIS/Utilities/CMSIS-SVD.xsd
+
+      - name: Check all SVD files against schema
+        shell: bash
+        run: |
+          exit_status=0
+          for svd in ./svd/*.svd; do
+            xmllint --noout --schema CMSIS-SVD.xsd $svd || exit_status=$?
+          done
+          exit $exit_status
+
+
   release:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Related to #27

A next PR could also add validation using SVDConv (see https://arm-software.github.io/CMSIS_5/SVD/html/svd_validate_file_pg.html), this PR is to test the waters as for whether there is any interest in having standards-compliant SVD files.

Currently, as described in #27, the tests fail. I'd like to fix that, but would like to do it in a robust way (so that when the SVDs are updated again, they don't break again). To do that, I'd need to know how the SVD files in this repo are created: are they created manually, are they generated from esp-idf, or from some Espressif-internal data? @jessebraham do you know this?